### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/externals/reqresp/Request.py
+++ b/externals/reqresp/Request.py
@@ -304,7 +304,7 @@ class Request:
 		c.setopt(pycurl.FOLLOWLOCATION, 1)
 
 	    proxy = req.getProxy()
-	    if proxy != None:
+	    if proxy is not None:
 		    c.setopt(pycurl.PROXY, proxy)
 		    if req.proxytype=="SOCKS5":
 			    c.setopt(pycurl.PROXYTYPE,pycurl.PROXYTYPE_SOCKS5)

--- a/framework/fuzzer/Fuzzer.py
+++ b/framework/fuzzer/Fuzzer.py
@@ -153,7 +153,7 @@ class Fuzzer:
 	    self.results_queue.task_done()
 	    raise item
 	# We are done if a None arrives
-	elif item == None:
+	elif item is None:
 	    self.results_queue.task_done()
 	    self.genReq.stats.mark_end()
 	    return None

--- a/framework/fuzzer/filter.py
+++ b/framework/fuzzer/filter.py
@@ -71,7 +71,7 @@ class FilterQ(FuzzQueue):
     def __compute_element(self, tokens):
 	element, operator, value = tokens[0]
 	
-	if value == 'BBB' and self.baseline == None:
+	if value == 'BBB' and self.baseline is None:
 	    raise FuzzException(FuzzException.FATAL, "FilterQ: specify a baseline value when using BBB")
 
 	if element == 'c' and value == 'XXX':
@@ -129,7 +129,7 @@ class FilterQ(FuzzQueue):
 	    except ParseException, e:
 		raise FuzzException(FuzzException.FATAL, "Incorrect filter expression. It should be composed of: c,l,w,h/and,or/=,<,>,!=,<=,>=")
 	else:
-	    if self.baseline == None and ('BBB' in self.hideparams['codes'] \
+	    if self.baseline is None and ('BBB' in self.hideparams['codes'] \
 		    or 'BBB' in self.hideparams['lines'] \
 		    or 'BBB' in self.hideparams['words'] \
 		    or 'BBB' in self.hideparams['chars']):

--- a/framework/utils/myqueue.py
+++ b/framework/utils/myqueue.py
@@ -97,13 +97,13 @@ class FuzzQueue(MyPriorityQueue, Thread):
 	    prio, item = self.get(True, 365 * 24 * 60 * 60)
 
 	    try:
-		if item == None and not cancelling:
+		if item is None and not cancelling:
 		    if self.wait_qout:
 			self.send_last(None)
 			self.qout_join()
 		    self.task_done()
 		    break
-		elif item == None and cancelling:
+		elif item is None and cancelling:
 		    self.send_last(None)
 		    self.task_done()
 		    break


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:wfuzz?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:wfuzz?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
